### PR TITLE
Callbacks wrapper feature and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,19 @@ An async pipeline approach to functional core - imperative shell from by Gary Be
 
 ## Fork differences
 
+### Step callbacks
+Each step admits now the following keywords: `on-start`, `on-complete`, `on-success` and `on-error`.
+The values should be functions with the signature `(fn [ctx step-res]`. If the value is not a function, and a `callbacks-wrapper-fn` function is given
+on the configuration, and that function will be called with that value.
+
+### callbacks-wrapper-fn
+As described above, if a `callbacks-wrapper-fn` function is provided on the configuration, the steps callbacks can be values instead of functions,
+and those values will be passed to the callback wrapper function. It should have the signature `(fn [callback-value ctx step-res])`.
+Can be used to dispatch events instead of calling functions. And because the values of the step callbacks are now data, it can be tested.
+
 ### Steps and callback functions signature changed to receive the result from the previous step
-The first steps's function signature remains the same, but consequent steps signature has been changed to `(fn [prev-step-res ctx])`.
-The first argument is the result of the previous step, and the second the context, same as before.
+The first steps's function signature remains the same, but consequent steps receive one more argument `(fn [ctx prev-step-res])`.
+The first argument remains the same - the context - and the second argument is the result of the previous step.
 
 ### Path is now optional
 If a step doesn't define a `:path`,  the step will not augment the context, and the result of the step can only be used by the next step
@@ -97,6 +107,10 @@ The following section describes the parameters `fonda/execute` accepts.
     |---|---|---|
     | `:tap` | No | A function that gets the context but doesn't augment it. If it succeeds the result is ignored. If asynchronous it will still block the pipeline and interrupt the execution whenever either an anomaly or an exception happen. |
     | `:name` | Yes | The name of the step as string or keyword |
+    | `:on-start` | Yes | A function with the signature `(fn [ctx])`, of a value if `callbacks-wrapper-fn` is provided on the configuration. It is called before the step is executed |
+    | `:on-complete` | Yes | A function with the signature `(fn [ctx step-res-or-exception-or-anomaly])`, of a value if `callbacks-wrapper-fn` is provided on the configuration. Called after the step is executed |
+    | `:on-success` | Yes | A function with the signature `(fn [ctx step-res])`, of a value if `callbacks-wrapper-fn` is provided on the configuration. Called after the step sucessfully executed |
+    | `:on-error` | Yes | A function with the signature `(fn [ctx step-exception-or-anomaly])`, of a value if `callbacks-wrapper-fn` is provided on the configuration. Called when the step returns an exception or an anomaly. |
 
   - processor
 
@@ -105,7 +119,11 @@ The following section describes the parameters `fonda/execute` accepts.
     | `:processor` or `:fn`| No | A function that gets the context and returns data. The data is [assoced-in](https://clojuredocs.org/clojure.core/assoc-in) at the given path Can be asynchronous. If asynchronous it will still block the pipeline and interrupt the execution whenever either an anomaly or an exception happen. |
     | `:path` | Yes | Path where to assoc the result of the processor. If not given, the step will not augment the context. |
     | `:name` | Yes | The name of the step as string or keyword. |
-
+    | `:on-start` | Yes | Same as in tap |
+    | `:on-complete` | Yes | Same as in tap |
+    | `:on-success` | Yes | Same as in tap |
+    | `:on-error` | Yes | Same as in tap |
+    
   - injector
 
     | Key | Optional? | Notes |
@@ -114,9 +132,9 @@ The following section describes the parameters `fonda/execute` accepts.
     | `:name` | Yes | The name of the injector step as string or keyword |
 
 
-- **on-exception**          Function called with an exception when any of the steps throws one.
-- **on-success**            Function called with the context if all steps succeed.
-- [Optional] **on-anomaly** Function called in case of anomaly with the anomaly data itself.
+- **on-exception**          Function with the signature `(fn [ctx exception])` called with the context and an exception when any of the steps throws one.
+- **on-success**            Function with the signature `(fn [ctx last-step-result])` called with the context if all steps succeed, and the last step result.
+- [Optional] **on-anomaly** Function with the signature `(fn [ctx exception])` called in case of anomaly with the context and the anomaly data itself.
 
 
 ## Full Example
@@ -150,7 +168,11 @@ The following section describes the parameters `fonda/execute` accepts.
   ;; Doesn't run this function, instead it runs the provided mock
   [{:processor  :example.full/get-remote-thing
     :name       "get-remote-thing"
-    :path       [:remote-thing-response]}
+    :path       [:remote-thing-response]
+    :on-start (fn [ctx] (println "Going to fetch the remote thing")
+    :on-success (fn [ctx res] (println "got the remote thing with response:" res))
+    :on-error (fn [ctx err-or-anomaly] (println "error fetching the remote thing:" err-or-anomaly))
+    :on-complete (fn [ctx step-res-or-exception-or-anomaly] (println "Done fetching the remote thing, the result (or error) is:" step-res-or-exception-or-anomaly)))}
 
    {:tap        :example.full/print-remote-thing}
    

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Each step admits now the following keywords: `on-start`, `on-complete`, `on-succ
 The values should be functions with the signature `(fn [ctx step-res]`. If the value is not a function, and a `callbacks-wrapper-fn` function is given
 on the configuration, and that function will be called with that value.
 
+### Global callbacks
+Global callbacks can now be a value that will be passed to the `callbacks-wrapper-fn`.
+
 ### callbacks-wrapper-fn
-As described above, if a `callbacks-wrapper-fn` function is provided on the configuration, the steps callbacks can be values instead of functions,
+As described above, if a `callbacks-wrapper-fn` function is provided on the configuration, the steps and global callbacks can be values instead of functions,
 and those values will be passed to the callback wrapper function. It should have the signature `(fn [callback-value ctx step-res])`.
 Can be used to dispatch events instead of calling functions. And because the values of the step callbacks are now data, it can be tested.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject elchache/fonda "0.0.2-SNAPSHOT"
+(defproject elchache/fonda "0.0.3"
   :url "https://github.com/arichiardi/fonda"
   :description "An async pipeline approach to functional core - imperative shell."
   :license {:name "Apache License"

--- a/src/fonda/core.cljs
+++ b/src/fonda/core.cljs
@@ -12,14 +12,16 @@
   Each step function - tap or processor - can be synchronous or asynchronous.
 
   - config: A map with:
-      - [opt] anomaly?           A function that gets a map and determines if it is an anomaly.
-      - [opt] ctx                The data that initializes the context. Must be a map.
-      - [opt] mock-fns           A map of functions that will replace the function on the step, matching the map
-                                 key with the step name
-      - [opt] anomaly-handlers   A map of functions indexed by step name that get called with a map
-                                 `{:ctx <ctx> :anomaly <anomaly>}` when the step returns an anomaly.
-      - [opt] exception-handlers A map of functions indexed by step name that get called with a map
-                                 `{:ctx <ctx> :exception <exception>}` when the step triggers an exception.
+      - [opt] anomaly?             A function that gets a map and determines if it is an anomaly.
+      - [opt] ctx                  The data that initializes the context. Must be a map.
+      - [opt] mock-fns             A map of functions that will replace the function on the step, matching the map
+                                   key with the step name
+      - [opt] anomaly-handlers     A map of functions indexed by step name that get called with a map
+                                   `{:ctx <ctx> :anomaly <anomaly>}` when the step returns an anomaly.
+      - [opt] exception-handlers   A map of functions indexed by step name that get called with a map
+                                   `{:ctx <ctx> :exception <exception>}` when the step triggers an exception.
+      - [opt] callbacks-wrapper-fn A function that gets called with the value of the on-* and the result of the step
+                                   `(fn [on-callback-val ctx step-res] ...)`
 
   - steps: Each item on the `steps` collection must be either a Tap, a Processor, or an Injector
 

--- a/src/fonda/core/specs.cljc
+++ b/src/fonda/core/specs.cljc
@@ -15,10 +15,11 @@
 (s/def ::ctx map?)
 (s/def ::anomaly-handlers ::handlers-map)
 (s/def ::exception-handlers ::handlers-map)
+(s/def ::callbacks-wrapper-fn (s/nilable fn?))
 
-(s/def ::on-success fn?)
-(s/def ::on-exception fn?)
-(s/def ::on-anomaly (s/nilable fn?))
+(s/def ::on-success some?)
+(s/def ::on-exception some?)
+(s/def ::on-anomaly (s/nilable any?))
 
 (s/def ::step-name-map
   (s/keys :opt-un [::name]))
@@ -35,7 +36,8 @@
                    ::mock-fns
                    ::ctx
                    ::anomaly-handlers
-                   ::exception-handlers]))
+                   ::exception-handlers
+                   ::callbacks-wrapper-fn]))
 
 (s/fdef fonda.core/execute
   :args (s/cat :config ::config

--- a/src/fonda/step/specs.cljc
+++ b/src/fonda/step/specs.cljc
@@ -1,10 +1,10 @@
 (ns fonda.step.specs
   (:require [clojure.spec.alpha :as s]))
 
-(s/def ::on-start (s/nilable fn?))
-(s/def ::on-success (s/nilable fn?))
-(s/def ::on-error (s/nilable fn?))
-(s/def ::on-complete (s/nilable fn?))
+(s/def ::on-start (s/nilable any?))
+(s/def ::on-success (s/nilable any?))
+(s/def ::on-error (s/nilable any?))
+(s/def ::on-complete (s/nilable any?))
 (s/def ::is-anomaly-error? (s/nilable fn?))
 
 ;; Tap step


### PR DESCRIPTION
- :callbacks-wrapper-fn can be passed in the configuration with the value as a function with signature [val ctx step-res] that will be called if a callback is a value instead of a function.
- fixed the bug that threw exception when the injector step returned nil
- fixed a bug that was calling the step callback functions with unresolved promises.